### PR TITLE
[semver:major] First official release without deploy to conda - v1.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,4 +108,4 @@ workflows:
             - integration-test-1
           filters:
             branches:
-              only: master
+              only: main


### PR DESCRIPTION
Follow-up of #1, the deploy was only on the `master` branch, not `main`