### PR TITLE
[semver:patch] Deploy python package to anaconda for new releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
       - checkout
       - psyplot-ci-orb/install_miniconda
       - psyplot-ci-orb/configure_conda
-      - psyplot-ci/install_opengl
+      - psyplot-ci-orb/install_opengl
   deploy-python:
     machine: true
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,10 +34,20 @@ jobs:
       - image: cimg/base:stable
     steps:
       - checkout
-      # "greet" is a sample command packaged with this orb config.
-      # This sample integration test will run as long as the greet command exists. Once you remove the greet command you should remove this line.
-      # Push new changes first, before adding new tests to your config.
-      - psyplot-ci-orb/greet
+      - psyplot-ci-orb/install_miniconda
+      - psyplot-ci-orb/configure_conda
+      - psyplot-ci/install_opengl
+  deploy-python:
+    machine: true
+    steps:
+      - checkout
+      - psyplot-ci-orb/install_miniconda
+      - psyplot-ci-orb/configure_conda
+      - run:
+          name: Build and deploy python package
+          command: |
+            python setup.py sdist
+            anaconda upload dist/psyplot-ci-orb*.tar.gz
 
 workflows:
   # Prior to producing a development orb (which requires credentials) basic validation, linting, and even unit testing can be performed.
@@ -98,6 +108,7 @@ workflows:
       # be skipped.
       # e.g. [semver:patch] will cause a patch version to be published.
       - orb-tools/dev-promote-prod-from-commit-subject:
+          name: publish-orb
           orb-name: psyplot/psyplot-ci-orb
           context: orb-publishing
           add-pr-comment: true
@@ -109,3 +120,7 @@ workflows:
           filters:
             branches:
               only: main
+      - deploy-python:
+          context: anaconda
+          requires:
+            - publish-orb

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ VCS = git
 style = pep440
 versionfile_source = src/python/psyplot_ci_orb/_version.py
 versionfile_build = psyplot_ci_orb/_version.py
-tag_prefix =
+tag_prefix = v
 parentdir_prefix = psyplot-ci-orb-
 
 [mypy]

--- a/src/python/psyplot_ci_orb/_version.py
+++ b/src/python/psyplot_ci_orb/_version.py
@@ -41,7 +41,7 @@ def get_config():
     cfg = VersioneerConfig()
     cfg.VCS = "git"
     cfg.style = "pep440"
-    cfg.tag_prefix = ""
+    cfg.tag_prefix = "v"
     cfg.parentdir_prefix = "psyplot-ci-orb-"
     cfg.versionfile_source = "src/python/psyplot_ci_orb/_version.py"
     cfg.verbose = False

--- a/src/scripts/build_docs.sh
+++ b/src/scripts/build_docs.sh
@@ -1,4 +1,5 @@
 build_docs() {
+    CONDADIR=$(eval echo "$CONDADIR")
     which conda || eval "$("${CONDADIR}"/bin/conda shell.bash hook)"
 
     if [ ${CONDAENV} != "" ]; then

--- a/src/scripts/conda_build.sh
+++ b/src/scripts/conda_build.sh
@@ -1,4 +1,5 @@
 conda_build() {
+    CONDADIR=$(eval echo "$CONDADIR")
     which conda || eval "$("${CONDADIR}"/bin/conda shell.bash hook)"
 
     conda build "${RECIPEDIR}" --python ${PYTHON_VERSION}

--- a/src/scripts/configure_conda.sh
+++ b/src/scripts/configure_conda.sh
@@ -1,4 +1,5 @@
 configure_conda() {
+    CONDADIR=$(eval echo "$CONDADIR")
     which conda || eval "$("${CONDADIR}"/bin/conda shell.bash hook)"
 
     conda config --set always_yes yes --set changeps1 no

--- a/src/scripts/deploy_docs.sh
+++ b/src/scripts/deploy_docs.sh
@@ -23,6 +23,7 @@ workflows:
               ignore: gh-pages
 EOF
 
+    CONDADIR=$(eval echo "$CONDADIR")
     which conda || eval "$("${CONDADIR}"/bin/conda shell.bash hook)"
     conda activate base
 

--- a/src/scripts/deploy_pkg.sh
+++ b/src/scripts/deploy_pkg.sh
@@ -1,5 +1,6 @@
 deploy_pkg() {
     # deploy to package to the anaconda channel
+    CONDADIR=$(eval echo "$CONDADIR")
     which conda || eval "$("${CONDADIR}"/bin/conda shell.bash hook)"
 
     conda activate base

--- a/src/scripts/install_miniconda.sh
+++ b/src/scripts/install_miniconda.sh
@@ -1,4 +1,5 @@
 install_miniconda() {
+    CONDADIR=$(eval echo "$CONDADIR")
     echo ""
     echo "Installing a fresh version of Miniconda."
     MINICONDA_URL="https://repo.anaconda.com/miniconda"


### PR DESCRIPTION
With this PR, we always push a python package to the [anaconda channel](https://anaconda.org/psyplot/psyplot-ci-orb)