### PR TITLE
cd to src_dir before building docs

### DIFF
--- a/src/scripts/build-docs.sh
+++ b/src/scripts/build-docs.sh
@@ -9,7 +9,10 @@ build-docs() {
         fi
     fi
 
-    sphinx-build ${SRC_DIR} ${BUILD_DIR}
+    WORKDIR="$(pwd)"
+    cd "${SRC_DIR}" || exit 1
+    sphinx-build . "${WORKDIR}/${BUILD_DIR}"
+    cd "${WORKDIR}" || exit 1
 }
 
 # Will not run if sourced for bats-core tests.


### PR DESCRIPTION
otherwise, examples that access local files may not work properly