### PR TITLE
compatibility fixes for anaconda-client=1.8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ package_dir =
     psyplot_ci_orb = src/python/psyplot_ci_orb
 packages = psyplot_ci_orb
 install_requires =
-    anaconda-client
+    anaconda-client>=1.8.0
     conda-build
 
 [options.entry_points]

--- a/src/commands/deploy-pkg.yml
+++ b/src/commands/deploy-pkg.yml
@@ -40,7 +40,7 @@ parameters:
       Version for the python deploy package to use. See
       https://anaconda.org/psyplot/psyplot-ci-orb
     type: string
-    default: "1.5.10"
+    default: "1.5.11"
 steps:
   - run:
       environment:

--- a/src/python/psyplot_ci_orb/__init__.py
+++ b/src/python/psyplot_ci_orb/__init__.py
@@ -122,7 +122,7 @@ def main(parser_args=None):
                     user,
                     package,
                     version,
-                    dependencies=[],
+                    requirements=[],
                     announce=None,
                     release_attrs=release_attrs,
                 )


### PR DESCRIPTION
this fixes the deployment for the anaconda-client API 1.8.0