### PR TITLE
Fix release with better escape of bash variables

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,10 +91,10 @@ workflows:
           dir: ./src/scripts
           exclude: SC2148,SC2001,SC2129
       # optional: Run BATS tests against your scripts
-      # - bats/run:
-      #     name: unit-tests
-      #     path: ./src/tests
-      #     exec_environment: << pipeline.parameters.unit-test-executor >>
+      - bats/run:
+          name: unit-tests
+          path: ./src/tests
+          exec_environment: << pipeline.parameters.unit-test-executor >>
       # If you accept building open source forks, protect your secrects behind a restricted context.
       # A job containing restricted context (which holds your orb publishing credentials) may only be accessed by a user with proper permissions.
       # An open source user may begin a pipeline with a PR, and once the pipeline is approved by an authorized user at this point, the pipeline will continue with the proper context permissions.
@@ -104,7 +104,7 @@ workflows:
           requires:
             - orb-tools/lint
             - orb-tools/pack
-            # - unit-tests
+            - unit-tests
             - shellcheck/check
       - hold-for-dev-publish:
           type: approval

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,10 +91,10 @@ workflows:
           dir: ./src/scripts
           exclude: SC2148,SC2001,SC2129
       # optional: Run BATS tests against your scripts
-      - bats/run:
-          name: unit-tests
-          path: ./src/tests
-          exec_environment: << pipeline.parameters.unit-test-executor >>
+      # - bats/run:
+      #     name: unit-tests
+      #     path: ./src/tests
+      #     exec_environment: << pipeline.parameters.unit-test-executor >>
       # If you accept building open source forks, protect your secrects behind a restricted context.
       # A job containing restricted context (which holds your orb publishing credentials) may only be accessed by a user with proper permissions.
       # An open source user may begin a pipeline with a PR, and once the pipeline is approved by an authorized user at this point, the pipeline will continue with the proper context permissions.
@@ -104,7 +104,7 @@ workflows:
           requires:
             - orb-tools/lint
             - orb-tools/pack
-            - unit-tests
+            # - unit-tests
             - shellcheck/check
       - hold-for-dev-publish:
           type: approval

--- a/src/scripts/create-release.sh
+++ b/src/scripts/create-release.sh
@@ -4,7 +4,7 @@ create-release() {
     [ "${TOKEN}" ] && GITHUB_TOKEN="${TOKEN}"
     jq -n \
       --arg tag "${NEW_TAG}" \
-      --arg name "${NEW_TAG}: ${RELEASE_TITLE}"
+      --arg name "${NEW_TAG}: ${RELEASE_TITLE}" \
       --arg body "${RELEASE_MESSAGE}" \
       "{tag_name: \$tag, name: \$name, body: \$body, draft: $DRAFT}" > release_body.json
 

--- a/src/scripts/create-release.sh
+++ b/src/scripts/create-release.sh
@@ -1,13 +1,15 @@
 create-release() {
+    sudo apt-get update
+    sudo apt-get install jq
     [ "${TOKEN}" ] && GITHUB_TOKEN="${TOKEN}"
-    cat > release_body.json << EOF
-{
-    "tag_name": "${NEW_TAG}",
-    "name": "${NEW_TAG}: ${RELEASE_TITLE}",
-    "body": "${RELEASE_MESSAGE}",
-    "draft": ${DRAFT}
-}
-EOF
+    jq -n \
+      --arg tag "${NEW_TAG}" \
+      --arg name "${NEW_TAG}: ${RELEASE_TITLE}"
+      --arg body "${RELEASE_MESSAGE}" \
+      "{tag_name: \$tag, name: \$name, body: \$body, draft: $DRAFT}" > release_body.json
+
+    cat release_body.json
+
     curl \
         -X POST \
         -H "Authorization: Token ${GITHUB_TOKEN}" \

--- a/src/scripts/create-tag.sh
+++ b/src/scripts/create-tag.sh
@@ -61,8 +61,8 @@ DoIncrement() {
 
     echo "export NEW_VERSION=\"${NEW_VERSION}\"" >> "$BASH_ENV"
     echo "export NEW_TAG=\"${NEW_TAG}\"" >> "$BASH_ENV"
-    echo "export RELEASE_TITLE=\"${RELEASE_TITLE}\"" >> "$BASH_ENV"
-    echo "export RELEASE_MESSAGE=\"${RELEASE_MESSAGE}\"" >> "$BASH_ENV"
+    echo "export RELEASE_TITLE=${RELEASE_TITLE@Q}" >> "$BASH_ENV"
+    echo "export RELEASE_MESSAGE=${RELEASE_MESSAGE@Q}" >> "$BASH_ENV"
 
     echo "export PR_MESSAGE=\"BotComment: *Production* version of package available for use - \\\`${NEW_TAG}\\\`\"" >> "$BASH_ENV"
 }

--- a/src/scripts/create-tag.sh
+++ b/src/scripts/create-tag.sh
@@ -62,10 +62,8 @@ DoIncrement() {
     echo "export NEW_VERSION=\"${NEW_VERSION}\"" >> "$BASH_ENV"
     echo "export NEW_TAG=\"${NEW_TAG}\"" >> "$BASH_ENV"
     echo "export RELEASE_TITLE=\"${RELEASE_TITLE}\"" >> "$BASH_ENV"
-
-    # insert newline characters into variable
-    RELEASE_MESSAGE=$(echo "${RELEASE_MESSAGE}" | sed -E ':a;N;$!ba;s/\r{0,1}\n/\\n/g')
     echo "export RELEASE_MESSAGE=\"${RELEASE_MESSAGE}\"" >> "$BASH_ENV"
+
     echo "export PR_MESSAGE=\"BotComment: *Production* version of package available for use - \\\`${NEW_TAG}\\\`\"" >> "$BASH_ENV"
 }
 

--- a/src/scripts/create-tag.sh
+++ b/src/scripts/create-tag.sh
@@ -61,8 +61,8 @@ DoIncrement() {
 
     echo "export NEW_VERSION=\"${NEW_VERSION}\"" >> "$BASH_ENV"
     echo "export NEW_TAG=\"${NEW_TAG}\"" >> "$BASH_ENV"
-    echo "export RELEASE_TITLE=${RELEASE_TITLE@Q}" >> "$BASH_ENV"
-    echo "export RELEASE_MESSAGE=${RELEASE_MESSAGE@Q}" >> "$BASH_ENV"
+    echo "export RELEASE_TITLE=$(printf '%q' "${RELEASE_TITLE}")" >> "$BASH_ENV"
+    echo "export RELEASE_MESSAGE=$(printf '%q' "${RELEASE_MESSAGE}")" >> "$BASH_ENV"
 
     echo "export PR_MESSAGE=\"BotComment: *Production* version of package available for use - \\\`${NEW_TAG}\\\`\"" >> "$BASH_ENV"
 }


### PR DESCRIPTION
The creation of releases on github failed if there is more content that needs to be escaped in the release body. This PR fixes this.